### PR TITLE
Use Authorization Code Flow.

### DIFF
--- a/se_leg_rp/views.py
+++ b/se_leg_rp/views.py
@@ -104,8 +104,7 @@ def get_state(**kwargs):
         # Initiate proofing
         args = {
             'client_id': current_app.oidc_client.client_id,
-            'response_type': 'code id_token token',
-            'response_mode': 'query',
+            'response_type': 'code',
             'scope': ['openid'],
             'redirect_uri': url_for('se_leg_rp.authorization_response', _external=True),
             'state': state,


### PR DESCRIPTION
Fix after incorrect `response_mode` handling was removed in SUNET/se-leg-op#7.
Requires SUNET/se-leg-developer#5.
